### PR TITLE
Enhance Hacker News source to fetch and process article content

### DIFF
--- a/pkg/source/hackernews/hackernews.go
+++ b/pkg/source/hackernews/hackernews.go
@@ -17,10 +17,12 @@ const (
 	itemURLFormat = apiBaseURL + "/item/%d.json"
 )
 
+// APIFetcher defines the interface for fetching from the API
 type APIFetcher interface {
 	FetchURLAsString(ctx context.Context, url string) (string, error)
 }
 
+// Source implements a Hacker News source.
 type Source struct {
 	name        string
 	maxArticles int
@@ -31,8 +33,10 @@ type Source struct {
 	procOptions *processor.Options
 }
 
+// ensure Source implements the source.Source interface
 var _ source.Source = (*Source)(nil)
 
+// New creates a new Hacker News source.
 func New(fetcher APIFetcher) *Source {
 	return &Source{
 		name:        "hackernews",
@@ -45,10 +49,12 @@ func New(fetcher APIFetcher) *Source {
 	}
 }
 
+// Name returns the source name.
 func (s *Source) Name() string {
 	return s.name
 }
 
+// Configure sets up the source with the provided configuration.
 func (s *Source) Configure(config map[string]interface{}) error {
 	if name, ok := config["name"].(string); ok && name != "" {
 		s.name = name
@@ -74,6 +80,7 @@ func (s *Source) Configure(config map[string]interface{}) error {
 	return nil
 }
 
+// HNItem represents a Hacker News API item.
 type HNItem struct {
 	ID          int    `json:"id"`
 	Title       string `json:"title"`
@@ -89,6 +96,7 @@ type HNItem struct {
 	Descendants int    `json:"descendants"`
 }
 
+// Fetch retrieves articles from Hacker News.
 func (s *Source) Fetch(ctx context.Context) ([]*models.Article, error) {
 	content, err := s.fetcher.FetchURLAsString(ctx, topStoriesURL)
 	if err != nil {

--- a/pkg/source/hackernews/hackernews_test.go
+++ b/pkg/source/hackernews/hackernews_test.go
@@ -173,6 +173,10 @@ func TestHackerNewsSource_Fetch(t *testing.T) {
 			if response, ok := responseMap[url]; ok {
 				return response, nil
 			}
+			// Mock behavior for article URLs
+			if url == "https://example.com/item100" || url == "https://example.com/item101" {
+				return "<html><body><article><h1>Article Content</h1><p>This is the full article content.</p></article></body></html>", nil
+			}
 			return "", fmt.Errorf("unexpected URL: %s", url)
 		},
 	}

--- a/pkg/source/hackernews/hackernews_test.go
+++ b/pkg/source/hackernews/hackernews_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shrik450/dijester/pkg/fetcher"
 )
 
+// MockHTTPClient implements the HTTPClient interface for testing
 type MockHTTPClient struct {
 	DoFunc func(req *http.Request) (*http.Response, error)
 }
@@ -19,11 +20,13 @@ func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return m.DoFunc(req)
 }
 
+// MockFetcher extends HTTPFetcher for testing
 type MockFetcher struct {
 	*fetcher.HTTPFetcher
 	MockFetchURLAsString func(ctx context.Context, url string) (string, error)
 }
 
+// FetchURLAsString overrides the HTTPFetcher method
 func (m *MockFetcher) FetchURLAsString(ctx context.Context, url string) (string, error) {
 	return m.MockFetchURLAsString(ctx, url)
 }


### PR DESCRIPTION
## Summary
- Modified the Hacker News source to fetch and process the full content of linked articles rather than just the metadata from HN
- Added readability processor to the HN source to extract main content from the article HTML
- Updated tests to ensure proper behavior with both self-posts and external links 

## Test plan
- Ran and passed all unit tests
- Successfully tested with the e2e-test script
- Verified that HN articles now contain the full content of the linked articles